### PR TITLE
Associating the citation subtypes to the appropriate form in lib4rido…

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -206,6 +206,11 @@ function lib4ridora_determine_form_name(AbstractObject $object) {
   module_load_include('inc', 'lib4ridora', 'includes/citation.subtypes');
   $subtypes = lib4ridora_determine_subtypes($object);
   $first = reset($subtypes);
+  foreach (lib4ridora_citation_form_subtypes() as $type => $info) {
+    if (in_array($first['name'], $info['genres'])) {
+      $first['form'] = $info['name'];
+    }
+  }
   return $first ? $first['form'] : NULL;
 }
 


### PR DESCRIPTION
…ra_determine_form_name so the correct form auto associates. If there is no genre it will provide the radio selection form.
