### PR TITLE
7.x pdf locker update

### DIFF
--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -32,15 +32,29 @@ function template_process_lib4ridora_pdf_materials(&$variables) {
  * Implements hook_preprocess_lib4ridora_pdf_link().
  */
 function template_preprocess_lib4ridora_pdf_link(&$variables) {
-  $ds = $variables['datastream'];
-  $values = lib4ridora_get_embargo_info($ds);
+  $values = lib4ridora_get_embargo_info($variables['datastream']);
+  $access = $values['availability'];
+
   $variables['pdf_link'] = $values;
-  $access = islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $variables['datastream']);
-  $variables['availability_classes'] = array(
-    'availability-text',
-  );
-  if ($access) {
+  $variables['availability_classes'] = array('availability-text');
+
+  if ($access == 'public') {
     $variables['span_classes_array'][] = 'fa fa-unlock-alt';
+  }
+  elseif ($access == 'date') {
+    $embargo = gmmktime(0, 0, 0, $values['embargo_date']['month'], $values['embargo_date']['day'], $values['embargo_date']['year']);
+
+    if (REQUEST_TIME > $embargo) {
+      $variables['span_classes_array'][] = 'fa fa-unlock-alt';
+    }
+    else {
+      // If user is logged in show the internal 'yellow' lock, otherwise use the
+      // standard grey color.
+      $variables['span_classes_array'][] = user_is_logged_in() ? 'fa fa-lock yellow' : $variables['span_classes_array'][] = 'fa fa-lock';
+    }
+  }
+  elseif (user_is_logged_in() && $access != 'private') {
+    $variables['span_classes_array'][] = 'fa fa-lock yellow';
   }
   else {
     $variables['span_classes_array'][] = 'fa fa-lock';
@@ -52,6 +66,7 @@ function template_preprocess_lib4ridora_pdf_link(&$variables) {
  */
 function template_process_lib4ridora_pdf_link(&$variables) {
   module_load_include('inc', 'lib4ridora', 'includes/embargo.form');
+
   $values = $variables['pdf_link'];
   if ($variables['statement']) {
     $availability = $values['availability'];

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -48,12 +48,12 @@ function template_preprocess_lib4ridora_pdf_link(&$variables) {
       $variables['span_classes_array'][] = 'fa fa-unlock-alt';
     }
     else {
-      // If user is logged in show the internal 'yellow' lock, otherwise use the
-      // standard grey color.
-      $variables['span_classes_array'][] = user_is_logged_in() ? 'fa fa-lock yellow' : 'fa fa-lock';
+      // If IP is internal show the 'yellow' lock, otherwise use the standard
+      // grey color.
+      $variables['span_classes_array'][] = lib4ridora_check_ip() ? 'fa fa-lock yellow' : 'fa fa-lock';
     }
   }
-  elseif (user_is_logged_in() && $access == 'intranet') {
+  elseif (lib4ridora_check_ip() && $access == 'intranet') {
     $variables['span_classes_array'][] = 'fa fa-lock yellow';
   }
   else {

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -50,10 +50,10 @@ function template_preprocess_lib4ridora_pdf_link(&$variables) {
     else {
       // If user is logged in show the internal 'yellow' lock, otherwise use the
       // standard grey color.
-      $variables['span_classes_array'][] = user_is_logged_in() ? 'fa fa-lock yellow' : $variables['span_classes_array'][] = 'fa fa-lock';
+      $variables['span_classes_array'][] = user_is_logged_in() ? 'fa fa-lock yellow' : 'fa fa-lock';
     }
   }
-  elseif (user_is_logged_in() && $access != 'private') {
+  elseif (user_is_logged_in() && $access == 'intranet') {
     $variables['span_classes_array'][] = 'fa fa-lock yellow';
   }
   else {
@@ -66,7 +66,6 @@ function template_preprocess_lib4ridora_pdf_link(&$variables) {
  */
 function template_process_lib4ridora_pdf_link(&$variables) {
   module_load_include('inc', 'lib4ridora', 'includes/embargo.form');
-
   $values = $variables['pdf_link'];
   if ($variables['statement']) {
     $availability = $values['availability'];


### PR DESCRIPTION
* Updated PDF locker color logic to use new yellow locker (for internal users).

* Logic is now based on the datastream's availability, not datastream access.

Related theme pull request: https://github.com/Lib4RI/libfourri_theme/pull/23